### PR TITLE
Update kernel to work with latest version of repl

### DIFF
--- a/Example.ipynb
+++ b/Example.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mexpr\n",
     "print \"Hello\\n\""
    ]
   },
@@ -16,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mexpr\n",
     "let x = addi 1 2 in\n",
     "x"
    ]
@@ -37,7 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mexpr\n",
     "(double 5, foo 2 3)"
    ]
   },
@@ -65,7 +62,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mexpr\n",
     "(odd 4, even 4)"
    ]
   },
@@ -98,7 +94,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mexpr\n",
     "count tree"
    ]
   },
@@ -121,7 +116,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mexpr\n",
     "map double [1,2,3]"
    ]
   },
@@ -203,10 +197,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mexpr\n",
     "use ArithBool in\n",
     "eval (If (IsZero (Num 0), (Num 1), (Num 3)))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -216,6 +216,7 @@
    "name": "mcore_kernel"
   },
   "language_info": {
+   "codemirror_mode": "ocaml",
    "file_extension": ".mc",
    "mimetype": "text/plain",
    "name": "MCore"

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ To try out the kernel, you will need the following dependencies:
 - The Miking bootstrap interpreter REPL. This should be available at the
   `develop` branch of the
   [main Miking repo](https://github.com/miking-lang/miking). Note that the
-  bootstrap interpreter needs to be available in `PATH` under the name `miking`.
+  bootstrap interpreter needs to be available in `PATH` under the name `mi`.
 
 ### Getting started
 
 Make sure you have all dependencies installed, and that the MCore bootstrap
-interpreter `miking` is in your `PATH`. Then, run the following command from the
+interpreter `mi` is in your `PATH`. Then, run the following command from the
 project root directory to install the kernel.
 
 ```

--- a/mcore_kernel/kernel.py
+++ b/mcore_kernel/kernel.py
@@ -18,7 +18,7 @@ for creating embedded domain-specific and general-purpose languages"""
 
     def __init__(self, **kwargs):
         Kernel.__init__(self, **kwargs)
-        self.wrapper = replwrap.REPLWrapper("miking repl --no-line-edit", ">> ", None, continuation_prompt=" | ")
+        self.wrapper = replwrap.REPLWrapper("mi repl --no-line-edit", ">> ", None, continuation_prompt=" | ")
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
                    allow_stdin=False):

--- a/mcore_kernel/kernel.py
+++ b/mcore_kernel/kernel.py
@@ -18,11 +18,11 @@ for creating embedded domain-specific and general-purpose languages"""
 
     def __init__(self, **kwargs):
         Kernel.__init__(self, **kwargs)
-        self.wrapper = replwrap.REPLWrapper("miking repl", ">> ", None, continuation_prompt=" | ")
+        self.wrapper = replwrap.REPLWrapper("miking repl --no-line-edit", ">> ", None, continuation_prompt=" | ")
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
                    allow_stdin=False):
-        output = self.wrapper.run_command(code + ";;")
+        output = self.wrapper.run_command(":{\n" + code + "\n:}")
         if not silent:
             stream_content = {'name': 'stdout', 'text': output}
             self.send_response(self.iopub_socket, 'stream', stream_content)


### PR DESCRIPTION
The updated REPL (https://github.com/miking-lang/miking/pull/115) breaks the current kernel. This PR updates the kernel to work with the updated REPL.